### PR TITLE
Paged enumerable overflow

### DIFF
--- a/src/Saritasa.Tools.Common/Pagination/PagedEnumerable`T.cs
+++ b/src/Saritasa.Tools.Common/Pagination/PagedEnumerable`T.cs
@@ -68,7 +68,7 @@ namespace Saritasa.Tools.Common.Pagination
         {
             this.Page = page;
             this.PageSize = pageSize;
-            this.TotalPages = (TotalCount + pageSize - 1) / pageSize;
+            this.TotalPages = GetTotalPages(TotalCount, PageSize);
         }
 
         /// <summary>
@@ -87,7 +87,15 @@ namespace Saritasa.Tools.Common.Pagination
         {
             this.Page = page;
             this.PageSize = pageSize;
-            this.TotalPages = (TotalCount + pageSize - 1) / pageSize;
+            this.TotalPages = GetTotalPages(TotalCount, PageSize);
+        }
+
+        private static int GetTotalPages(int totalItemsCount, int pageSize)
+        {
+            long buffer = pageSize;
+            buffer += totalItemsCount;
+            buffer -= 1;
+            return (int)(buffer / pageSize);
         }
 
         #region IMetadataEnumerable<PagedEnumerableMetadata, T>

--- a/test/Saritasa.Tools.Common.Tests/FlowTests.cs
+++ b/test/Saritasa.Tools.Common.Tests/FlowTests.cs
@@ -106,6 +106,29 @@ namespace Saritasa.Tools.Common.Tests
             Assert.Equal(3, pagedList4.Count());
         }
 
+        [Fact]
+        public void Paged_enumerable_should_work_with_max_page_size()
+        {
+            // Arrange
+            var sourceData = new List<int>()
+            {
+                1,
+                2
+            };
+
+            // Act
+            var pagedResult = PagedEnumerable.Create(sourceData, 1, int.MaxValue);
+
+            // Assert
+            Assert.Equal(1, pagedResult.TotalPages);
+            Assert.Equal(int.MaxValue, pagedResult.Limit);
+            Assert.Equal(2, pagedResult.TotalCount);
+            Assert.True(pagedResult.IsFirstPage);
+            Assert.True(pagedResult.IsLastPage);
+            Assert.Equal(1, pagedResult.Page);
+            Assert.Equal(int.MaxValue, pagedResult.PageSize);
+        }
+
         /// <summary>
         /// Custom exception for tests only.
         /// </summary>


### PR DESCRIPTION
Fixes overflow error when using `int.MaxValue` as page size