### PR TITLE
Multismtp sender credentials

### DIFF
--- a/src/Saritasa.Tools.Emails/MultiSmtpClientEmailSender.cs
+++ b/src/Saritasa.Tools.Emails/MultiSmtpClientEmailSender.cs
@@ -55,8 +55,8 @@ namespace Saritasa.Tools.Emails
 
             var newClient = new SmtpClient(client.Host, client.Port)
             {
-                Credentials = client.Credentials,
                 UseDefaultCredentials = client.UseDefaultCredentials,
+                Credentials = client.Credentials,
                 DeliveryFormat = client.DeliveryFormat,
                 DeliveryMethod = client.DeliveryMethod,
                 EnableSsl = client.EnableSsl,


### PR DESCRIPTION
It looks like if we set `UseDefaultCredentials` property after `Credentials`, the `Credentials` property is always getting cleared.