### PR TITLE
Update ruleset to not allow using invalid cref in docstrings

### DIFF
--- a/tools/Saritasa.ruleset
+++ b/tools/Saritasa.ruleset
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RuleSet Name="Saritasa Code Rules" Description="Saritasa code style conventions for .NET projects." ToolsVersion="14.0">
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp" RuleNamespace="Microsoft.CodeAnalysis.CSharp">
+    <Rule Id="CS1574" Action="Error" />
+  </Rules>
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1001" Action="Warning" />
     <Rule Id="CA1009" Action="Warning" />


### PR DESCRIPTION
Updated the ruleset configuration to not allow invalid references (`cref`) in docstrings.